### PR TITLE
V0.2.0 - Adding Key Confirmation & Relay Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2019-10-07
+## [0.2.0] - 2020-10-07
 ### Added
-- Key confirmation using HKDF from [key_confirmation](https://github.com/landhb/portal/tree/key_confirmation)
-- Relay efficiency improvements from [multiproc_relay](https://github.com/landhb/portal/tree/multiproc_relay)
+- Key confirmation using HKDF 
+- Relay efficiency improvements, polling only for read events bi-directionally until the intermediary pipe needs to be drained (i.e request exchange or the end of the transfer)
 
 ### Changed
 - The main Portal struct's direction field is now a `Direction` instead of an `Option<Direction>`, this is a breaking change since 0.1.0 clients won't be able to communicate with a 0.2.0 relay
@@ -17,10 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Library Documentation
 
-## [0.1.0] - 2019-10-02
+## [0.1.0] - 2020-10-02
 ### Added
 - Initial publication
 
-
+```
 [0.2.0]: 
 [0.1.0]: https://github.com/landhb/portal/tree/b228f9a8d0e765c1f4f2f37799df5d55483dfece
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0] - 2019-10-07
+### Added
+- Key confirmation using HKDF from [key_confirmation](https://github.com/landhb/portal/tree/key_confirmation)
+- Relay efficiency improvements from [multiproc_relay](https://github.com/landhb/portal/tree/multiproc_relay)
+
+### Changed
+- The main Portal struct's direction field is now a `Direction` instead of an `Option<Direction>`, this is a breaking change since 0.1.0 clients won't be able to communicate with a 0.2.0 relay
+
+### Fixed
+- Library Documentation
+
+## [0.1.0] - 2019-10-02
+### Added
+- Initial publication
+
+
+[0.2.0]: 
+[0.1.0]: https://github.com/landhb/portal/tree/b228f9a8d0e765c1f4f2f37799df5d55483dfece

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle 2.3.0",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,7 +717,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e8f9d776bbe83f1ff24951f7cc19140fb7ff8d0378463c4c4955f6b0d3e503"
 dependencies = [
  "digest 0.8.1",
- "hmac",
+ "hmac 0.7.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe1149865383e4526a43aee8495f9a325f0b806c63ce6427d06336a590abbbc9"
+dependencies = [
+ "digest 0.9.0",
+ "hmac 0.8.1",
 ]
 
 [[package]]
@@ -716,8 +736,18 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.7.0",
  "digest 0.8.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -999,6 +1029,7 @@ dependencies = [
  "bincode",
  "chacha20poly1305",
  "hex 0.4.2",
+ "hkdf 0.9.0",
  "memmap",
  "rand 0.7.3",
  "serde",
@@ -1324,7 +1355,7 @@ checksum = "363b721158126474100d7f9ff9e5ce11d1866042787de6834e19cc20c8112f6f"
 dependencies = [
  "curve25519-dalek",
  "hex 0.3.2",
- "hkdf",
+ "hkdf 0.7.1",
  "num-bigint",
  "rand 0.6.5",
  "sha2 0.8.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +859,18 @@ dependencies = [
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log",
+ "mio",
+ "slab",
 ]
 
 [[package]]
@@ -1047,6 +1065,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "mio",
+ "mio-extras",
  "os_pipe",
  "portal-lib",
  "threadpool",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,10 +1044,12 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "daemonize",
+ "lazy_static",
  "libc",
  "mio",
  "os_pipe",
  "portal-lib",
+ "threadpool",
 ]
 
 [[package]]
@@ -1452,6 +1454,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "portal-client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-std",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "portal-lib"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "portal-relay"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "daemonize",

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 
-## Portal  [![license-badge][]][license] [![rust-version-badge][]][rust-version]
+## Portal  
+[![cargo-badge-lib][]][cargo-lib] [![docs-badge-lib][]][docs-lib] [![license-badge][]][license] [![rust-version-badge][]][rust-version]  
 
 Securely & quickly transport your files.
 
-| ------- | ------------------------------------- | ---------------------------------------- |
-| portal-client   | [![cargo-badge-client][]][cargo-client]  | [![docs-badge-client][]][docs-client]                  |
-| portal-lib   | [![cargo-badge-lib][]][cargo-lib]  | [![docs-badge-lib][]][docs-lib]                  |
-| portal-relay | -        | -         |
 
-### Client Install
+### Client Install 
+[![cargo-badge-client][]][cargo-client] 
+
+The client binary can be installed via Cargo:
 
 ```
 cargo install portal-client

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 ## Portal  
-[![cargo-badge-lib][]][cargo-lib] [![docs-badge-lib][]][docs-lib] [![license-badge][]][license] [![rust-version-badge][]][rust-version]  
+[![cargo-badge-lib][]][cargo-lib] [![docs-badge-lib][]][docs-lib] [![license-badge][]][license] [![rust-version-badge][]][rust-version] [![build][]][build-url] [![codecov][]][codecov-url]  
 
 Securely & quickly transport your files.
 
@@ -92,3 +92,9 @@ This tool works extremely similarly to Wormhole written by [Brian Warner](https:
 [docs-client]: https://docs.rs/portal-client
 [docs-badge-lib]: https://docs.rs/portal-lib/badge.svg?style=flat-square
 [docs-lib]: https://docs.rs/portal-lib
+
+[codecov]: https://img.shields.io/codecov/c/github/landhb/portal?style=flat-square
+[codecov-url]: https://codecov.io/gh/landhb/portal
+
+[build]: https://img.shields.io/github/workflow/status/landhb/portal/Build/master?style=flat-square
+[build-url]: https://github.com/landhb/portal/actions?query=workflow%3ABuild

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 
-## Portal 
-
-[![crates.io](https://img.shields.io/crates/v/portal-lib.svg)](https://crates.io/crates/portal-lib)
-[![Documentation](https://docs.rs/portal-lib/badge.svg)](https://docs.rs/portal-lib)
-![Apache2/MIT licensed][license-image]
-![Rust Version][rustc-image]
+## Portal  [![license-badge][]][license] [![rust-version-badge][]][rust-version]
 
 Securely & quickly transport your files.
+
+| ------- | ------------------------------------- | ---------------------------------------- |
+| portal-client   | [![cargo-badge-client][]][cargo-client]  | [![docs-badge-client][]][docs-client]                  |
+| portal-lib   | [![cargo-badge-lib][]][cargo-lib]  | [![docs-badge-lib][]][docs-lib]                  |
+| portal-relay | -        | -         |
 
 ### Client Install
 
@@ -78,5 +78,17 @@ This tool works extremely similarly to Wormhole written by [Brian Warner](https:
 
 
 [//]: # (badges)
-[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[license-badge]: https://img.shields.io/badge/license-MIT/Apache--2.0-lightgray.svg?style=flat-square
+[license]: #license
+[rust-version-badge]: https://img.shields.io/badge/rust-latest%20stable-blue.svg?style=flat-square
+[rust-version]: #rust-version-policy
+
+[cargo-badge-client]: https://img.shields.io/crates/v/portal-client.svg?style=flat-square
+[cargo-client]: https://crates.io/crates/portal-client
+[cargo-badge-lib]: https://img.shields.io/crates/v/portal-lib.svg?style=flat-square
+[cargo-lib]: https://crates.io/crates/portal-lib
+
+[docs-badge-client]: https://docs.rs/portal-client/badge.svg?style=flat-square
+[docs-client]: https://docs.rs/portal-client
+[docs-badge-lib]: https://docs.rs/portal-lib/badge.svg?style=flat-square
+[docs-lib]: https://docs.rs/portal-lib

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ This tool works extremely similarly to Wormhole written by [Brian Warner](https:
 [rust-version-badge]: https://img.shields.io/badge/rust-latest%20stable-blue.svg?style=flat-square
 [rust-version]: #rust-version-policy
 
-[cargo-badge-client]: https://img.shields.io/crates/v/portal-client.svg?style=flat-square
+[cargo-badge-client]: https://img.shields.io/crates/v/portal-client.svg?style=flat-square&label=portal-client
 [cargo-client]: https://crates.io/crates/portal-client
-[cargo-badge-lib]: https://img.shields.io/crates/v/portal-lib.svg?style=flat-square
+[cargo-badge-lib]: https://img.shields.io/crates/v/portal-lib.svg?style=flat-square&label=portal-lib
 [cargo-lib]: https://crates.io/crates/portal-lib
 
 [docs-badge-client]: https://docs.rs/portal-client/badge.svg?style=flat-square

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portal-client"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["landhb <landhb@github>"]
 edition = "2018"
 description = """
@@ -24,7 +24,7 @@ path="src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-portal-lib = {path ="../lib",version = "0.1.0"}
+portal-lib = {path ="../lib",version = "0.2.0"}
 anyhow = "1.0.32"
 clap = "2.33.3"
 rpassword = "5.0.0"

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -167,10 +167,9 @@ fn transfer(
             file.sync_file_state(&mut client)?;
             println!("{}", "Ok!".green());
 
-            // This will be empty for files created with create_file()
-            let chunks = portal.get_chunks(&file, portal::CHUNK_SIZE);
-
-            for data in chunks.into_iter() {
+            // iterate over the file in chunks, attempting to send
+            // each one 
+            for data in file.get_chunks(portal::CHUNK_SIZE) {
                 match client.write_all(&data) {
                     Ok(_) => {}
                     Err(_) => {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,16 +1,16 @@
 extern crate portal_lib as portal;
 
-use portal::Portal;
-use std::net::TcpStream;
-use std::io::Write;
-use std::error::Error;
-use clap::{Arg, App, SubCommand,AppSettings};
 use anyhow::Result;
-use indicatif::{ProgressBar, ProgressStyle};
+use clap::{App, AppSettings, Arg, SubCommand};
 use colored::*;
-use serde::{Serialize, Deserialize};
-use dns_lookup::lookup_host;
 use directories::UserDirs;
+use dns_lookup::lookup_host;
+use indicatif::{ProgressBar, ProgressStyle};
+use portal::Portal;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::io::Write;
+use std::net::TcpStream;
 
 #[macro_use]
 extern crate lazy_static;
@@ -26,15 +26,14 @@ struct AppConfig {
 }
 
 impl ::std::default::Default for AppConfig {
-    fn default() -> Self { 
-
+    fn default() -> Self {
         // select ~/Downloads or /tmp for downloads
         let hdir = UserDirs::new();
         let ddir = match &hdir {
-            Some(home) => home.download_dir().map_or("/tmp",|v| v.to_str().unwrap()),
+            Some(home) => home.download_dir().map_or("/tmp", |v| v.to_str().unwrap()),
             None => "/tmp",
         };
-        
+
         Self {
             relay_host: String::from("portal-relay.landhb.dev"),
             relay_port: portal::DEFAULT_PORT,
@@ -45,23 +44,27 @@ impl ::std::default::Default for AppConfig {
 
 macro_rules! log_status {
     ($($arg:tt)*) => (println!("{} {}", "[*]".blue().bold(), format_args!($($arg)*)));
-} 
+}
 
 macro_rules! log_error {
     ($($arg:tt)*) => (println!("{} {}", "[!]".red().bold(), format_args!($($arg)*)));
-} 
+}
 
 macro_rules! log_success {
     ($($arg:tt)*) => (println!("{} {}", "[+]".green().bold(), format_args!($($arg)*)));
-} 
+}
 
 macro_rules! log_wait {
     ($($arg:tt)*) => (print!("{} {}", "[...]".yellow().bold(), format_args!($($arg)*)); std::io::stdout().flush().unwrap(););
-} 
+}
 
-
-fn transfer(mut portal: Portal, msg: Vec<u8>, fpath: &str, mut client: std::net::TcpStream, is_reciever: bool) -> Result<(), Box<dyn Error>>  {
-
+fn transfer(
+    mut portal: Portal,
+    msg: Vec<u8>,
+    fpath: &str,
+    mut client: std::net::TcpStream,
+    is_reciever: bool,
+) -> Result<(), Box<dyn Error>> {
     /*
      * Step 1: Portal Request
      */
@@ -86,40 +89,37 @@ fn transfer(mut portal: Portal, msg: Vec<u8>, fpath: &str, mut client: std::net:
     client.write_all(&msg)?;
     let confirm_msg = Portal::read_confirmation_from(&mut client)?;
     match portal.derive_key(&confirm_msg) {
-        Ok(_) => {},
+        Ok(_) => {}
         Err(_) => {
             log_error!("Incorrect channel ID or peer disconnected. Try again.");
             std::process::exit(0);
         }
     }
 
-
     /*
      * Step 4: Key confirmation
      */
     match portal.confirm_peer(&mut client) {
-        Ok(_) => {log_success!("Peer confirmed!");},
+        Ok(_) => {
+            log_success!("Peer confirmed!");
+        }
         Err(_) => {
             log_error!("Incorrect pass-phrase or peer disconnected. Try again.");
             std::process::exit(0);
         }
     }
-    
-        
+
     /*
      * Step 5: Begin file transfer
      */
     let mut total = 0;
-    let pstyle = 
-        ProgressStyle::default_bar()
+    let pstyle = ProgressStyle::default_bar()
         .template("[{elapsed_precise}] [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")
         .progress_chars("#>-");
 
     match is_reciever {
-
         true => {
-
-            let fname = format!("{}/{}",fpath, resp.get_file_name()?);
+            let fname = format!("{}/{}", fpath, resp.get_file_name()?);
             let fsize = resp.get_file_size();
             log_status!("Downloading file: {:?}, size: {:?}", fname, fsize);
 
@@ -131,11 +131,11 @@ fn transfer(mut portal: Portal, msg: Vec<u8>, fpath: &str, mut client: std::net:
 
             // Receive until connection is done
             log_status!("Waiting for peer to begin transfer...");
-            let len = match file.download_file(&client,|x| {pb.set_position(x)}) {
+            let len = match file.download_file(&client, |x| pb.set_position(x)) {
                 Ok(n) => n,
                 Err(e) => {
-                  log_error!("download failed: {:?}",e);
-                  std::process::exit(-1);
+                    log_error!("download failed: {:?}", e);
+                    std::process::exit(-1);
                 }
             };
 
@@ -146,11 +146,14 @@ fn transfer(mut portal: Portal, msg: Vec<u8>, fpath: &str, mut client: std::net:
             // Decrypt the file
             log_wait!("Decrypting file...");
             file.decrypt()?;
-            println!("{}","Ok!".green());
+            println!("{}", "Ok!".green());
         }
         false => {
-
-            log_status!("Sending file: {:?}, size: {:?}", portal.get_file_name().unwrap(),portal.get_file_size());
+            log_status!(
+                "Sending file: {:?}, size: {:?}",
+                portal.get_file_name().unwrap(),
+                portal.get_file_size()
+            );
 
             let pb = ProgressBar::new(portal.get_file_size());
             pb.set_style(pstyle);
@@ -162,14 +165,20 @@ fn transfer(mut portal: Portal, msg: Vec<u8>, fpath: &str, mut client: std::net:
             log_wait!("Encrypting file...");
             file.encrypt()?;
             file.sync_file_state(&mut client)?;
-            println!("{}","Ok!".green());
+            println!("{}", "Ok!".green());
 
             // This will be empty for files created with create_file()
-            let chunks = portal.get_chunks(&file,portal::CHUNK_SIZE);
+            let chunks = portal.get_chunks(&file, portal::CHUNK_SIZE);
 
             for data in chunks.into_iter() {
-                client.write_all(&data)?;
-                total += portal::CHUNK_SIZE; 
+                match client.write_all(&data) {
+                    Ok(_) => {}
+                    Err(_) => {
+                        log_error!("peer disconnected or connection lost");
+                        std::process::exit(-1);
+                    }
+                }
+                total += portal::CHUNK_SIZE;
                 pb.set_position(total as u64);
             }
 
@@ -180,32 +189,32 @@ fn transfer(mut portal: Portal, msg: Vec<u8>, fpath: &str, mut client: std::net:
     Ok(())
 }
 
-
 fn main() -> Result<(), Box<dyn Error>> {
-
     let matches = App::new("portal")
-                  .version(env!("CARGO_PKG_VERSION"))
-                  .author(env!("CARGO_PKG_AUTHORS"))
-                  .about("Quick & Safe File Transfers")
-                  .setting(AppSettings::ArgRequiredElseHelp)
-                  .subcommand(SubCommand::with_name("send")
-                              .about("Send a file")
-                              .arg(Arg::with_name("filename")
-                                  .short("f")
-                                  .takes_value(true)
-                                  .required(true)
-                                  .index(1)
-                                  .help("file to transfer"))
-                  )
-                  .subcommand(SubCommand::with_name("recv")
-                              .about("Recieve a file")
-                              .arg(Arg::with_name("download_folder")
-                                  .short("d")
-                                  .takes_value(true)
-                                  .required(false)
-                                  .help("override download folder"))
-                  )
-                  .get_matches();
+        .version(env!("CARGO_PKG_VERSION"))
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .about("Quick & Safe File Transfers")
+        .setting(AppSettings::ArgRequiredElseHelp)
+        .subcommand(
+            SubCommand::with_name("send").about("Send a file").arg(
+                Arg::with_name("filename")
+                    .short("f")
+                    .takes_value(true)
+                    .required(true)
+                    .index(1)
+                    .help("file to transfer"),
+            ),
+        )
+        .subcommand(
+            SubCommand::with_name("recv").about("Recieve a file").arg(
+                Arg::with_name("download_folder")
+                    .short("d")
+                    .takes_value(true)
+                    .required(false)
+                    .help("override download folder"),
+            ),
+        )
+        .get_matches();
 
     // Fix terminal output on windows
     #[cfg(target_os = "windows")]
@@ -213,7 +222,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Load/create config location
     let mut cfg: AppConfig = confy::load("portal")?; // CARGO_BIN_NAME is nightly only
-    log_status!("Using portal.toml config, relay: {}!", cfg.relay_host.yellow());
+    log_status!(
+        "Using portal.toml config, relay: {}!",
+        cfg.relay_host.yellow()
+    );
 
     // Determin the IP address to connect to
     let addr: std::net::IpAddr = match cfg.relay_host.parse() {
@@ -223,9 +235,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             ips[0]
         }
     };
-    
-    let addr: std::net::SocketAddr = format!("{}:{}",addr, cfg.relay_port).parse()?;
 
+    let addr: std::net::SocketAddr = format!("{}:{}", addr, cfg.relay_port).parse()?;
 
     let client = match TcpStream::connect_timeout(&addr, std::time::Duration::new(3, 0)) {
         Ok(res) => res,
@@ -237,29 +248,26 @@ fn main() -> Result<(), Box<dyn Error>> {
     log_success!("Connected to {:?}!", addr);
 
     match matches.subcommand() {
-        ("send", Some(args)) =>  { 
-
+        ("send", Some(args)) => {
             let id = gen_phrase(1);
             let pass = gen_phrase(3);
-            log_success!("Tell your peer their pass-phrase is: {:?}", format!("{}-{}",id,pass));
+
+            log_success!(
+                "Tell your peer their pass-phrase is: {:?}",
+                format!("{}-{}", id, pass)
+            );
+
             let file = args.value_of("filename").unwrap();
 
-            let (mut req,msg) = Portal::init(
-                portal::Direction::Sender,
-                id,
-                pass,
-                Some(file.to_string()),
-            );
+            let (mut req, msg) =
+                Portal::init(portal::Direction::Sender, id, pass, Some(file.to_string()));
 
             let metadata = std::fs::metadata(file)?;
             req.set_file_size(metadata.len());
 
-            transfer(req,msg,file,client, false)?;
-            
-        },
-        ("recv", Some(args)) =>  { 
-
-
+            transfer(req, msg, file, client, false)?;
+        }
+        ("recv", Some(args)) => {
             let pass = rpassword::read_password_from_tty(Some("Enter pass-phrase: ")).unwrap();
 
             // check if we need to override the download location
@@ -272,17 +280,18 @@ fn main() -> Result<(), Box<dyn Error>> {
             let id = pass.next().unwrap().to_string();
             let opass = pass.collect::<Vec<&str>>().join("-");
 
-            let (req,msg) = Portal::init(
+            let (req, msg) = Portal::init(
                 portal::Direction::Receiver,
                 id,
                 opass,
                 None, // receiver will get the filename from the sender
             );
 
-            transfer(req,msg,&cfg.download_location,client, true)?;
-
-        },
-        _ => {println!("Please provide a valid subcommand. Run portal -h for more information.");},
+            transfer(req, msg, &cfg.download_location, client, true)?;
+        }
+        _ => {
+            println!("Please provide a valid subcommand. Run portal -h for more information.");
+        }
     }
 
     Ok(())

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -9,7 +9,6 @@ use anyhow::Result;
 use indicatif::{ProgressBar, ProgressStyle};
 use colored::*;
 use serde::{Serialize, Deserialize};
-use confy;
 use dns_lookup::lookup_host;
 use directories::UserDirs;
 
@@ -270,7 +269,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             // Parse ID from password
             let mut pass = pass.split('-');
-            let id = pass.nth(0).unwrap().to_string();
+            let id = pass.next().unwrap().to_string();
             let opass = pass.collect::<Vec<&str>>().join("-");
 
             let (req,msg) = Portal::init(

--- a/client/src/wordlist.rs
+++ b/client/src/wordlist.rs
@@ -27,8 +27,7 @@ pub fn gen_phrase(count: usize) -> String {
         phrase.push(*WORDS.get(&y).unwrap());
     }
 
-    let r = phrase.join("-");
-    r.to_string()
+    phrase.join("-")
 }
 
 lazy_static! {

--- a/client/src/wordlist.rs
+++ b/client/src/wordlist.rs
@@ -1,22 +1,21 @@
 use rand::Rng;
 use std::collections::HashMap;
 
-/** 
+/**
  * Generates a pass-phrase with the EFF's dice generated
  * word list
  *
  * https://www.eff.org/dice
  */
 pub fn gen_phrase(count: usize) -> String {
-    
-    let mut phrase = vec!();
+    let mut phrase = vec![];
 
     let mut rng = rand::thread_rng();
     let mut get_index = || {
         let mut pos = 1;
         let mut res = 0;
         for _i in 0..5 {
-            res += rng.gen_range(1, 6)*pos;
+            res += rng.gen_range(1, 6) * pos;
             pos *= 10;
         }
         res
@@ -32,7 +31,7 @@ pub fn gen_phrase(count: usize) -> String {
 
 lazy_static! {
     pub static ref WORDS: HashMap<u32, &'static str> = {
-        let mut words = HashMap::new(); 
+        let mut words = HashMap::new();
         words.insert(11111, "abacus");
         words.insert(11112, "abdomen");
         words.insert(11113, "abdominal");

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -30,3 +30,4 @@ sha2 = "0.9.1"
 hex = "0.4.2"
 chacha20poly1305 = {version="0.6.0",features=["heapless"]}
 rand = "0.7.3"
+hkdf = "0.9.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portal-lib"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["landhb <landhb@github>"]
 edition = "2018"
 description = """

--- a/lib/src/chunks.rs
+++ b/lib/src/chunks.rs
@@ -1,8 +1,5 @@
-//! chunks.rs
-//! 
 //! Provides an chunks based iterator over a PortalFile
 //!
-
 
 
 /**

--- a/lib/src/chunks.rs
+++ b/lib/src/chunks.rs
@@ -1,3 +1,10 @@
+//! chunks.rs
+//! 
+//! Provides an chunks based iterator over a PortalFile
+//!
+
+
+
 /**
  * An iterator of an mmap'd PortalFile
  */

--- a/lib/src/chunks.rs
+++ b/lib/src/chunks.rs
@@ -1,4 +1,6 @@
-
+/**
+ * An iterator of an mmap'd PortalFile
+ */
 pub struct PortalChunks<'a, T: 'a> {
     v: &'a [T],
     chunk_size: usize,
@@ -7,7 +9,7 @@ pub struct PortalChunks<'a, T: 'a> {
 impl<'a, T: 'a> PortalChunks<'a, T> {
     pub fn init(data: &'a [T], chunk_size: usize) -> PortalChunks<'a,T> {
         PortalChunks{
-            v: data, // TODO: verify that this is zero-copy/move
+            v: data, 
             chunk_size: chunk_size,
         }
     }

--- a/lib/src/chunks.rs
+++ b/lib/src/chunks.rs
@@ -10,7 +10,7 @@ impl<'a, T: 'a> PortalChunks<'a, T> {
     pub fn init(data: &'a [T], chunk_size: usize) -> PortalChunks<'a,T> {
         PortalChunks{
             v: data, 
-            chunk_size: chunk_size,
+            chunk_size,
         }
     }
 }

--- a/lib/src/errors.rs
+++ b/lib/src/errors.rs
@@ -26,11 +26,3 @@ pub enum PortalError {
 }
 
 
-pub fn underlying_io_error_kind(error: &anyhow::Error) -> Option<io::ErrorKind> {
-    for cause in error.chain() {
-        if let Some(io_error) = cause.downcast_ref::<io::Error>() {
-            return Some(io_error.kind());
-        }
-    }
-    None
-}

--- a/lib/src/file.rs
+++ b/lib/src/file.rs
@@ -2,15 +2,13 @@ use chacha20poly1305::ChaCha20Poly1305;
 use anyhow::Result;
 use memmap::MmapMut;
 use rand::Rng;
-
 use std::io::Write;
 use serde::{Serialize, Deserialize};
-use chacha20poly1305::{Nonce,Tag}; 
+use chacha20poly1305::{Nonce,Tag,aead::AeadInPlace}; 
 
 
 use crate::errors::PortalError;
 
-use chacha20poly1305::aead::AeadInPlace;
 
 
 /**
@@ -29,6 +27,11 @@ pub struct PortalFile {
     pos: usize,
 }
 
+/**
+ * PortalFile metadata containing encryption state 
+ * data that must be transferred to the peer for 
+ * decryption
+ */
 #[derive(Serialize, Deserialize, PartialEq)]
 struct StateMetadata {
     nonce: Vec<u8>,

--- a/lib/src/file.rs
+++ b/lib/src/file.rs
@@ -45,8 +45,8 @@ impl PortalFile {
 
     pub fn init(mmap: MmapMut, cipher: ChaCha20Poly1305) -> PortalFile {
         PortalFile{
-            mmap: mmap,
-            cipher: cipher,
+            mmap,
+            cipher,
             pos: 0,
             state: StateMetadata {
                 nonce: Vec::new(),

--- a/lib/src/file.rs
+++ b/lib/src/file.rs
@@ -1,3 +1,8 @@
+//! file.rs
+//! 
+//! Provides an interface into the PortalFile abstraction
+//!
+
 use chacha20poly1305::ChaCha20Poly1305;
 use anyhow::Result;
 use memmap::MmapMut;
@@ -55,6 +60,16 @@ impl PortalFile {
         }
     }
 
+    /// Encrypts the current PortalFile, by encrypting the mmap'd memory in-place
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// let file = portal.load_file("/tmp/file");
+    /// let result: Result<()> = file.encrypt();
+    /// ```
     pub fn encrypt(&mut self) -> Result<()> {
 
         // Generate random nonce
@@ -72,6 +87,16 @@ impl PortalFile {
 
     }
 
+    /// Decrypts the current PortalFile, by decrypting the mmap'd memory in-place
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// let file = portal.load_file("/tmp/file");
+    /// let result: Result<()> = file.decrypt();
+    /// ```
     pub fn decrypt(&mut self) -> Result<()> {
         let nonce = Nonce::from_slice(&self.state.nonce);
         let tag = Tag::from_slice(&self.state.tag);

--- a/lib/src/file.rs
+++ b/lib/src/file.rs
@@ -177,12 +177,12 @@ impl PortalFile {
 
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use crate::{Portal,Direction};
     use std::io::{Read,Write};
 
-    struct MockTcpStream {
-        data: Vec<u8>,
+    pub struct MockTcpStream {
+        pub data: Vec<u8>,
     }
 
     impl Read for MockTcpStream {
@@ -255,6 +255,7 @@ mod tests {
         assert_eq!(&file.mmap[..], &new_file.mmap[..]);
 
         new_file.decrypt().unwrap(); // should not panic
+        stream.flush().unwrap(); // just for coverage reporting, does nothing
     }
 
     #[test]
@@ -286,4 +287,5 @@ mod tests {
         assert_ne!(file_before, file_encrypted);
         assert_eq!(file_before, file_after);
     }
+
 }

--- a/lib/src/file.rs
+++ b/lib/src/file.rs
@@ -156,3 +156,39 @@ impl PortalFile {
     }
 }
 
+
+#[cfg(test)]
+mod tests {
+    
+    use crate::{Portal,Direction};
+
+    #[test]
+    fn test_encrypt_decrypt() {
+
+        // receiver
+        let dir = Direction::Receiver;
+        let pass ="test".to_string();
+        let (mut receiver,receiver_msg) = Portal::init(dir,"id".to_string(),pass,None);
+
+        // sender
+        let dir = Direction::Sender;
+        let pass ="test".to_string();
+        let (mut sender,sender_msg) = Portal::init(dir,"id".to_string(),pass,None);
+
+        // we need a key to be able to encrypt
+        receiver.derive_key(sender_msg.as_slice()).unwrap();
+        sender.derive_key(receiver_msg.as_slice()).unwrap();
+
+
+        let mut file = sender.load_file("/etc/passwd").unwrap();
+
+        let file_before = String::from_utf8((&file.mmap[..]).to_vec());
+        file.encrypt().unwrap();
+        let file_encrypted = String::from_utf8((&file.mmap[..]).to_vec());
+        file.decrypt().unwrap();
+        let file_after = String::from_utf8((&file.mmap[..]).to_vec());
+
+        assert_ne!(file_before, file_encrypted);
+        assert_eq!(file_before, file_after);
+    }
+}

--- a/lib/src/file.rs
+++ b/lib/src/file.rs
@@ -61,13 +61,6 @@ impl PortalFile {
 
     /** 
      * Encrypts the current PortalFile, by encrypting the mmap'd memory in-place
-     *
-     * # Examples
-     *
-     * ```
-     * let file = portal.load_file("/tmp/file");
-     * let result: Result<()> = file.encrypt();
-     * ```
      */
     pub fn encrypt(&mut self) -> Result<()> {
 
@@ -88,13 +81,6 @@ impl PortalFile {
 
     /** 
      * Decrypts the current PortalFile, by decrypting the mmap'd memory in-place
-     *
-     * # Examples
-     *    
-     * ```
-     * let file = portal.load_file("/tmp/file");
-     * let result: Result<()> = file.decrypt();
-     * ```
      */
     pub fn decrypt(&mut self) -> Result<()> {
         let nonce = Nonce::from_slice(&self.state.nonce);
@@ -148,7 +134,7 @@ impl PortalFile {
      *
      * # Examples
      *     
-     * ```
+     * ```ignore
      * for data in file.get_chunks(portal::CHUNK_SIZE) {
      *      client.write_all(&data)?
      *      total += data.len();

--- a/lib/src/file.rs
+++ b/lib/src/file.rs
@@ -91,7 +91,11 @@ impl PortalFile {
         }
     }
 
-
+    /** 
+     * Writes the nonce and tag for this file to the provided writer. Use
+     * after encrypting a file to communicate state data to the peer that will
+     * decrypt the file
+     */
     pub fn sync_file_state<W>(&mut self, mut writer: W) -> Result<usize> 
     where 
         W: std::io::Write {
@@ -100,6 +104,17 @@ impl PortalFile {
         Ok(data.len())
     }
 
+    /** 
+     * Downloads a file, first by retrieving the Tag and Nonce communicated by 
+     * sync_file_state() and then reading in the file until EOF
+     *
+     * ```ignore
+     * Peer A                  Peer B
+     * encrypt()               download_file()
+     * sync_file_state()       decrypt()
+     * // send chunks
+     * ```
+     */
     pub fn download_file<R,F>(&mut self,mut reader: R, callback: F) -> Result<u64>
     where 
         R: std::io::Read, 
@@ -149,6 +164,10 @@ impl PortalFile {
         )
     }
 
+
+    /** 
+     * Writes the provided data to the file in-memory at the current position
+     */
     pub fn write_given_chunk(&mut self,data: &[u8]) -> Result<u64> {
         (&mut self.mmap[self.pos..]).write_all(&data)?;
         self.pos += data.len();

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -145,6 +145,10 @@ pub enum Direction {
     Receiver,
 }
 
+/**
+ * Method to compair arbitrary &[u8] slices, used internally
+ * to compare key exchange and derivation data
+ */
 fn compare_key_derivations(a: &[u8], b: &[u8]) -> std::cmp::Ordering {
     for (ai, bi) in a.iter().zip(b.iter()) {
         match ai.cmp(&bi) {
@@ -160,7 +164,7 @@ fn compare_key_derivations(a: &[u8], b: &[u8]) -> std::cmp::Ordering {
 impl Portal {
     
     /**
-     * Initialize 
+     * Initialize a new portal request
      */
     pub fn init(direction: Direction, 
                 id: String,
@@ -308,7 +312,7 @@ impl Portal {
      */
     pub fn get_chunks<'a>(&self, data: &'a PortalFile, chunk_size: usize) -> PortalChunks<'a,u8> {
         PortalChunks::init(
-            &data.mmap[..], // TODO: verify that this is zero-copy/move
+            &data.mmap[..], // TODO: verify that this is zero-copy
             chunk_size,
         )
     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -189,14 +189,14 @@ impl Portal {
             filename = Some(f.to_string());
         }
 
-        return (Portal {
-            direction: direction,
+        (Portal {
+            direction,
             id: id_hash,
-            filename: filename,
+            filename,
             filesize: 0,
             state: Some(s1),
             key: None,
-        }, outbound_msg);
+        }, outbound_msg)
     }
 
     /**
@@ -224,7 +224,7 @@ impl Portal {
     /**
      * Attempt to deserialize from a vector
      */
-    pub fn parse(data: &Vec<u8>) -> Result<Portal> {
+    pub fn parse(data: &[u8]) -> Result<Portal> {
         Ok(bincode::deserialize(&data)?)
     }
 
@@ -380,7 +380,7 @@ impl Portal {
                     return Ok(());
                 }
 
-                return Err(PortalError::BadMsg.into());
+                Err(PortalError::BadMsg.into())
             }
         }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -100,7 +100,7 @@ use chacha20poly1305::{ChaCha20Poly1305, Key};
 use chacha20poly1305::aead::{NewAead};
 
 pub mod errors;
-mod file;
+pub mod file;
 mod chunks;
 
 
@@ -108,7 +108,14 @@ use errors::PortalError;
 use file::PortalFile;
 use chunks::PortalChunks;
 
+/**
+ * Arbitrary port for the Portal protocol
+ */
 pub const DEFAULT_PORT: u16 = 13265;
+
+/**
+ * Default chunk size
+ */
 pub const CHUNK_SIZE: usize = 65535;
 
 
@@ -138,7 +145,10 @@ pub struct Portal{
 }
 
 
-
+/**
+ * An enum to describe the direction of each file transfer 
+ * participant (i.e Sender/Receiver)
+ */
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub enum Direction {
     Sender,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -16,14 +16,14 @@
 //! use portal_lib::{Portal,Direction};
 //!
 //! // receiver
-//! let dir = Direction::Receiver;
+//! let id = "id".to_string();
 //! let pass ="test".to_string();
-//! let (mut receiver,receiver_msg) = Portal::init(dir,"id".to_string(),pass,None);
+//! let (mut receiver,receiver_msg) = Portal::init(Direction::Receiver,id,pass,None);
 //!
 //! // sender
-//! let dir = Direction::Sender;
+//! let id = "id".to_string();
 //! let pass ="test".to_string();
-//! let (mut sender,sender_msg) = Portal::init(dir,"id".to_string(),pass,None);
+//! let (mut sender,sender_msg) = Portal::init(Direction::Sender,id,pass,None);
 //!
 //! // Both clients should derive the same key
 //! receiver.derive_key(&sender_msg).unwrap();

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -30,7 +30,7 @@
 //! sender.derive_key(&receiver_msg).unwrap();
 //! 
 //! ```
-//! You can use the confirm_peer() method to verify that a remote peer has derived the same key 
+//! You can use the `Portal::confirm_peer()` method to verify that a remote peer has derived the same key 
 //! as you, as long as the communication stream implements the std::io::Read and std::io::Write traits.
 //!
 //! Example of Sending a file:
@@ -648,7 +648,7 @@ mod tests {
 
     #[test]
     fn test_compressed_edwards_size() {
-        
+
         // The exchanged message is the CompressedEdwardsY + 1 byte for the SPAKE direction
         let edwards_point = <spake2::Ed25519Group as spake2::Group>::Element::default();
         let compressed = edwards_point.compress();

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portal-relay"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["landhb <landhb@github>"]
 edition = "2018"
 description = """
@@ -17,7 +17,7 @@ license = "Apache-2.0 OR MIT"
 
 
 [dependencies]
-portal-lib = {path = "../lib",version = "0.1.0"}
+portal-lib = {path = "../lib",version = "0.2.0"}
 mio = "0.6.22" 
 anyhow = "1.0.32"
 os_pipe = "0.9.2"

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -23,3 +23,6 @@ anyhow = "1.0.32"
 os_pipe = "0.9.2"
 libc = "0.2.77" # splice syscall
 daemonize = "0.4.1"
+lazy_static = "1.4.0"
+threadpool = "1.8.1"
+ipc-channel = "0.11.0"

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -25,4 +25,5 @@ libc = "0.2.77" # splice syscall
 daemonize = "0.4.1"
 lazy_static = "1.4.0"
 threadpool = "1.8.1"
-ipc-channel = "0.11.0"
+#ipc-channel = "0.11.0"
+mio-extras = "2.0.6"

--- a/relay/src/handlers.rs
+++ b/relay/src/handlers.rs
@@ -66,10 +66,9 @@ pub fn tcp_splice (
             return Ok(true);
         }
 
-        // break if blocking
-        if rx < 0 && (errno == libc::EWOULDBLOCK || errno == libc::EAGAIN) {
-            break;
-        }
+        // We cannot break here on EWOULDBLOCK since the first splice may return EWOULDBLOCK
+        // if the pipe is full, in that case we'd want to complete the second splice to clear
+        // the pipe
 
         // Done reading
         if rx == 0 {

--- a/relay/src/handlers.rs
+++ b/relay/src/handlers.rs
@@ -25,6 +25,46 @@ pub fn handle_client_event (
     event: &Event) -> Result<(bool,isize)> {
 
     let mut trx = 0;
+    
+    // Readable events will be file data from the Sender
+    if event.readiness().is_readable() {
+
+        let writer = match &endpoint.peer_writer {
+            Some(p) => p,
+            None => {
+                // end this connection if there is no peer pipe
+                return Ok((true,0));
+            }
+        };
+
+        let src_fd = endpoint.stream.as_raw_fd();
+        let dst_fd = writer.as_raw_fd();
+
+        unsafe { let errno = libc::__errno_location(); *errno = 0;}
+        loop {
+            unsafe {
+                trx = libc::splice(src_fd, 0 as *mut libc::loff_t, dst_fd, 0 as *mut libc::loff_t, 65535, libc::SPLICE_F_NONBLOCK);  
+            }
+
+            // check if connection is closed
+            let errno = std::io::Error::last_os_error().raw_os_error();
+            if trx < 0 && errno != Some(0) && errno != Some(libc::EWOULDBLOCK) && errno != Some(libc::EAGAIN) {
+                return Ok((true,trx));
+            }
+
+            log!("got {} bytes from {:?}, errno: {:?}", trx, endpoint.dir,errno);
+
+            // break if blocking
+            if trx < 0 && (errno == Some(libc::EWOULDBLOCK) || errno == Some(libc::EAGAIN)) {
+                break;
+            }
+
+            // Done sending
+            if trx == 0 {
+                return Ok((true,trx));
+            } 
+        }
+    }
 
     // Writeable events will mean data is ready to be forwarded to the Reciever
     if event.readiness().is_writable() {
@@ -42,81 +82,34 @@ pub fn handle_client_event (
         let src_fd = reader.as_raw_fd();
 
         unsafe { let errno = libc::__errno_location(); *errno = 0;}
-        while let Some(errno) = std::io::Error::last_os_error().raw_os_error() {
-
+        loop  { 
             unsafe {
                 trx = libc::splice(src_fd, 0 as *mut libc::loff_t, dst_fd, 0 as *mut libc::loff_t, 65535, libc::SPLICE_F_NONBLOCK);    
             }
 
-            if trx < 0 && errno != 0 && errno != libc::EWOULDBLOCK && errno != libc::EAGAIN {
+            let errno = std::io::Error::last_os_error().raw_os_error().unwrap();
+
+            // check for errors
+            if trx < 0  && errno != 0 && errno != libc::EWOULDBLOCK && errno != libc::EAGAIN {
                 println!("exiting due to trx: {:?} errno {:?}", trx, errno);
                 return Ok((true,trx));
             }
 
+            log!("sent {} bytes to {:?}, errno: {:?}", trx, endpoint.dir, errno);
+
+            // break if blocking
             if trx < 0 && (errno == libc::EWOULDBLOCK || errno == libc::EAGAIN) {
                 break;
             }
 
-            log!("sent {} bytes to {:?}", trx, endpoint.dir);
-
-
             if trx == 0 {
                 break;
-            }
+            } 
 
-        }
-
-        // If this is the Sender we wrote to, then we've just completed
-        // msg exchange and are now only interested in READABLE events from
-        // the sender
-        if endpoint.dir == portal::Direction::Sender && endpoint.writable == false {
-            registry.reregister(&mut endpoint.stream,token,Ready::readable(),PollOpt::level())?;
         }
         
     }
 
-    
-    // Readable events will be file data from the Sender
-    if event.readiness().is_readable() {
-
-        let writer = match &endpoint.peer_writer {
-            Some(p) => p,
-            None => {
-                // end this connection if there is no peer pipe
-                return Ok((true,0));
-            }
-        };
-
-        let src_fd = endpoint.stream.as_raw_fd();
-        let dst_fd = writer.as_raw_fd();
-
-        unsafe {
-            let errno = libc::__errno_location(); 
-            *errno = 0;
-            trx = libc::splice(src_fd, 0 as *mut libc::loff_t, dst_fd, 0 as *mut libc::loff_t, 65535, libc::SPLICE_F_NONBLOCK);  
-        }
-
-        // check if connection is closed
-        let errno = std::io::Error::last_os_error().raw_os_error();
-        if trx < 0 && errno != Some(libc::EWOULDBLOCK) && errno != Some(libc::EAGAIN) {
-            return Ok((true,trx));
-        }
-
-        if trx == 0 {
-            return Ok((true,trx));
-        }
-
-        log!("got {} bytes from {:?}", trx, endpoint.dir);
-
-        // If this is the Reciever, the we've received the last message
-        // to be read, we're now only interested in WRITABLE events,
-        // we'll use edge triggering for this endpoint since we'll want to fully
-        // drain the pipe when a writable event occurs
-        if endpoint.dir == portal::Direction::Receiver {
-            registry.reregister(&mut endpoint.stream,token,Ready::writable(),PollOpt::level())?;
-        }
-
-    }
 
     Ok((false,trx))
 }

--- a/relay/src/handlers.rs
+++ b/relay/src/handlers.rs
@@ -136,7 +136,7 @@ pub fn drain_pipe(
         }
 
         if trx == 0 {
-            break;
+            return Ok((true,0));
         } 
 
     }

--- a/relay/src/logging.rs
+++ b/relay/src/logging.rs
@@ -1,9 +1,7 @@
 // Disable warnings
-
 #[allow(unused_macros)]
 
 // The debug version
-
 #[cfg(debug_assertions)]
 #[macro_export]
 macro_rules! log {

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -29,6 +29,14 @@ use protocol::register;
 const SERVER: Token = Token(0);
 const CHANNEL: Token = Token(1);
 
+/* From the cloudfare blog: 
+ * There is no "good" splice buffer size. Anecdotical evidence
+ * says that it should be no larger than 512KiB since this is
+ * the max we can expect realistically to fit into cpu
+ * cache. */
+const MAX_SPLICE_SIZE: usize = 512*1024;
+
+
 lazy_static! {
     static ref PENDING_ENDPOINTS: Mutex<HashMap<String, Endpoint>> = Mutex::new(HashMap::new());
 }

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -1,6 +1,6 @@
 extern crate portal_lib as portal;
 
-use portal::Portal;
+use portal::{Portal,Direction};
 use std::collections::HashMap;
 use std::error::Error;
 use std::cell::{RefCell};
@@ -31,8 +31,8 @@ const SERVER: Token = Token(0);
 const CHANNEL: Token = Token(1);
 
 lazy_static! {
-    static ref ENDPOINTS: Mutex<HashMap<Token, Endpoint>> = Mutex::new(HashMap::new());
-    static ref UNIQUE_TOKEN: Mutex<Token> = Mutex::new(Token(CHANNEL.0+1));
+    static ref PENDING_ENDPOINTS: Mutex<HashMap<String, Endpoint>> = Mutex::new(HashMap::new());
+    //static ref UNIQUE_TOKEN: Mutex<Token> = Mutex::new(Token(CHANNEL.0+1));
 }
 
 #[derive(Debug)]
@@ -42,7 +42,7 @@ pub struct Endpoint {
     stream: TcpStream,
     peer_writer: Option<PipeWriter>,
     peer_reader: Option<PipeReader>,
-    peer_token: Option<Token>,
+    token: Option<Token>,
     time_added: SystemTime,
 }
 
@@ -72,6 +72,16 @@ fn daemonize() -> Result<(),daemonize::DaemonizeError> {
 }
 
 
+// increment the polling token by one
+// for each new client connection
+pub fn next(current: &mut Token) -> Token {
+    let next = current.0;
+    current.0 += 1;
+    Token(next)
+}
+
+
+
 
 fn main() -> Result<(), Box<dyn Error>> {
 
@@ -99,6 +109,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     let (tx, mut rx) = channel::<EndpointPair>();
     poll.register(&mut rx, CHANNEL, Ready::readable(), PollOpt::edge())?;
 
+    // Active endpoint pairs
+    let id_lookup: Rc<RefCell<HashMap<Token, String>>> = Rc::new(RefCell::new(HashMap::new()));
+    let endpoints: Rc<RefCell<HashMap<String, EndpointPair>>> = Rc::new(RefCell::new(HashMap::new()));
+
+
+    let mut unique_token = Token(CHANNEL.0+1);
+
     // Start an event loop.
     loop {
 
@@ -111,6 +128,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             match event.token() {
 
+                /*
+                 * When receiving an incoming connection, use the threadpool to accept
+                 * Portal requests without blocking the main loop
+                 */
                 SERVER => loop {
 
                     // If this is an event for the server, it means a connection
@@ -140,53 +161,95 @@ fn main() -> Result<(), Box<dyn Error>> {
                         }
                     });
                 }
+                /*
+                 * When a worker thread has completed pairing two peers, the EndpointPair
+                 * will be send over an MPSC channel to be added to the list of file descriptors
+                 * we're polling 
+                 */
                 CHANNEL => {
-                    let pair = match rx.try_recv() {
+                    let mut pair = match rx.try_recv() {
                         Ok(p) => p,
                         Err(_) => {continue;},
                     };
 
                     println!("ADDING PAIR {:?}", pair);
+
+                    let sender_token = next(&mut unique_token);
+                    let receiver_token = next(&mut unique_token);
+
+                    pair.sender.token = Some(sender_token);
+                    pair.receiver.token = Some(receiver_token);
+
+                    poll.register(&mut pair.sender.stream, sender_token, Ready::readable()|Ready::writable(),PollOpt::edge())?;
+                    poll.register(&mut pair.receiver.stream, receiver_token, Ready::readable(),PollOpt::level())?;
+
+                    id_lookup.borrow_mut().entry(sender_token).or_insert(pair.sender.id.clone());
+                    id_lookup.borrow_mut().entry(receiver_token).or_insert(pair.sender.id.clone());
+                    endpoints.borrow_mut().entry(pair.sender.id.clone()).or_insert(pair);
+
+                    println!("SUCCESS");
                 }
+                /*
+                 * Any other events indicate there is data we need to channel between two TCP connections
+                 * at this time we primarily use splice() to do that
+                 */
                 token => {
 
-                    let mut ref_endpoints = ENDPOINTS.lock().unwrap(); //endpoints.borrow_mut();
+                    let mut ref_endpoints = endpoints.borrow_mut();
+                    let lookup = id_lookup.borrow();
 
-                    // get the client that will be performing the read/write
-                    let client = match ref_endpoints.get_mut(&token) {
+                    let id = match lookup.get(&token) {
+                        Some(id) => id,
+                        None => {
+                            continue;
+                        },
+                    };
+
+                    // get the EndpointPair that generated the event
+                    let pair = match ref_endpoints.get_mut(id) {
                         Some(p) => p,
                         None => {
                             continue;
                         },
                     };
 
-                    // check that the client has a peer first
-                    let peer_token = match client.peer_token {
-                        Some(v) => v,
-                        None => {continue;},
+                    // determine which Endpoint is readable
+                    let (side,stream,endpoint) = match token {
+                        x if Some(x) == pair.sender.token => {(Direction::Sender,&pair.sender.stream, &pair.sender)},
+                        x if Some(x) == pair.receiver.token => {(Direction::Receiver,&pair.receiver.stream, &pair.receiver)},
+                        _ => {continue;},
                     };
 
 
-                    log!("event {:?} on token {:?}, peer: {:?}", event, token, peer_token);
+                    log!("event {:?} on token {:?}, side: {:?}", event, token, side);
 
+                    // Turn off writable notifications if on, this is only used to kick off the 
+                    // initial message exchange by draining on of the peer's pipes
+                    if event.readiness().is_writable() {
+                        handlers::drain_pipe(&poll,endpoint, &event)?;
+                        poll.reregister(stream, token, Ready::readable(),PollOpt::level())?;
+                    }
 
                     // perform the action
-                    let (done,trx) = handlers::handle_client_event(token,&poll, client, &event)?;
+                    let (done,trx) = handlers::tcp_splice(side,&poll, pair, &event)?;
 
                     log!("handler finished {:?}", done); 
 
                     // If this connection is finished, or our peer has disconnected
                     // shutdown the connection
-                    if done || (trx <= 0 && !ref_endpoints.contains_key(&peer_token)) {
-                        log!("Removing endpoint for {:?}", token);
-                        if let Some(mut client) = ref_endpoints.remove(&token) {
-                            poll.deregister(&mut client.stream)?;
-                            match client.stream.shutdown(std::net::Shutdown::Both) {
+                    if done {
+                        log!("Removing endpoint for {:?}", pair);
+                        poll.deregister(&mut pair.sender.stream)?;
+                        poll.deregister(&mut pair.receiver.stream)?;
+                        match pair.sender.stream.shutdown(std::net::Shutdown::Both) {
                                 Ok(_) => {},
                                 Err(_) => {},
-                            }
                         }
-                    }
+                        match pair.receiver.stream.shutdown(std::net::Shutdown::Both) {
+                                Ok(_) => {},
+                                Err(_) => {},
+                        }
+                    } 
 
                 }
             }

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -1,5 +1,3 @@
-//#[macro_use]
-//extern crate lazy_static;
 extern crate portal_lib as portal;
 
 use portal::Portal;
@@ -11,14 +9,29 @@ use std::io::Write;
 use mio::net::{TcpListener, TcpStream};
 use mio::{Events, Ready, Poll, Token, PollOpt}; 
 use os_pipe::{pipe,PipeReader,PipeWriter};
+use std::sync::Mutex;
+use threadpool::ThreadPool;
 use std::time::SystemTime;
+
+#[macro_use]
+extern crate lazy_static;
 
 mod handlers;
 mod networking;
+
+#[macro_use]
 mod logging;
+mod protocol;
+
+use protocol::register;
 
 // Some tokens to allow us to identify which event is for which socket.
 const SERVER: Token = Token(0);
+
+lazy_static! {
+    static ref ENDPOINTS: Mutex<HashMap<Token, Endpoint>> = Mutex::new(HashMap::new());
+    static ref UNIQUE_TOKEN: Mutex<Token> = Mutex::new(Token(SERVER.0+1));
+}
 
 #[derive(Debug)]
 pub struct Endpoint {
@@ -31,14 +44,6 @@ pub struct Endpoint {
     time_added: SystemTime,
 }
 
-
-// increment the polling token by one
-// for each new client connection
-fn next(current: &mut Token) -> Token {
-    let next = current.0;
-    current.0 += 1;
-    Token(next)
-}
 
 #[cfg(not(debug_assertions))]
 fn daemonize() -> Result<(),daemonize::DaemonizeError> {
@@ -60,6 +65,7 @@ fn daemonize() -> Result<(),daemonize::DaemonizeError> {
 }
 
 
+
 fn main() -> Result<(), Box<dyn Error>> {
 
     // Only daemonize in release
@@ -79,12 +85,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Start listening for incoming connections.
     poll.register(&mut server, SERVER, Ready::readable(), PollOpt::level())?;
 
-    let mut unique_token = Token(SERVER.0+1);
+    // Pre-allocate a few registration threads
+    let thread_pool = ThreadPool::new(4);
 
-    // Use to reference existing endpoints and their polling tokens
-    let endpoints: Rc<RefCell<HashMap<Token, Endpoint>>> = Rc::new(RefCell::new(HashMap::new()));
-
-    
     // Start an event loop.
     loop {
 
@@ -98,13 +101,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             match event.token() {
 
                 SERVER => loop {
-
-                    // Clear old entries before accepting, will keep
-                    // connections < 15 min old
-                    endpoints.borrow_mut().retain(|_, v| 
-                        !v.peer_token.is_none() || (
-                        v.time_added.elapsed().unwrap().as_secs() < 
-                        std::time::Duration::from_secs(60*15).as_secs())); 
 
                     // If this is an event for the server, it means a connection
                     // is ready to be accepted.
@@ -122,145 +118,19 @@ fn main() -> Result<(), Box<dyn Error>> {
                     log!("[+] Got connection from {:?}", _addr);
 
                     
-                    let mut received_data = Vec::with_capacity(1024);
-                    while received_data.len() == 0 {
-                        match networking::recv_generic(&mut connection,&mut received_data) {
-                            Ok(v) if v < 0 => {break;}, // done recieving
+                    // TODO set RECV_TIMEO
+                    thread_pool.execute(move || {
+                        match register(connection) {
                             Ok(_) => {},
-                            Err(_) => {
-                                break;
-                            }
-                        }
-                    }
-
-                    log!("{:?}", received_data.len());
-
-                    // attempt to recieve a portal request
-                    let req: Portal = match Portal::parse(&received_data) {
-                            Ok(r) => r,
                             Err(_e) => {
-                                log!("{:?}", _e);
-                                continue;
-                            },
-                    };
-
-                    log!("req: {:?}", req);
-
-                    match req.get_direction() {
-
-                        portal::Direction::Receiver => {
-
-                            // Lookup Sender token
-                            let id = req.get_id();
-                            let ref_endpoints = endpoints.borrow();
-                            let search = ref_endpoints.iter()
-                            .find_map(|(key, val)| if *val.id == *id  { Some(key) } else { None });
-
-                            let peer_token  = match search {
-                                Some(t) => t.clone(),
-                                None => {continue;}
-                            };
-                            
-                            // drop the immutable reference because we need a mutable one
-                            drop(ref_endpoints);
-
-                            let mut ref_endpoints = endpoints.borrow_mut();
-                            let mut peer = match ref_endpoints.get_mut(&peer_token) {
-                                Some(p) => p,
-                                None => {continue;},
-                            };
-
-
-                            // if the peer already has a connection, disregard this one
-                            if !peer.peer_token.is_none() {
-                                let _ = connection.shutdown(std::net::Shutdown::Both);
-                                continue;
+                                log!("{}",_e);
                             }
-                            
-                            // assign token since the peer is valid
-                            let token = next(&mut unique_token);
-                            
-                            // create the pipes for this transfer
-                            let (reader2, mut writer2) = pipe().unwrap();
-                            
-                            // write the acknowledgement response to both pipe endpoints
-                            let resp = req.serialize()?;
-                            writer2.write_all(&resp)?;
-
-                            log!("Finished writing to pipes");
-
-                            // update the peer with the pipe information
-                            let old_reader = std::mem::replace(&mut peer.peer_reader, Some(reader2));
-                            peer.peer_token = Some(token);
-                            
-                            // set socket to WRITABLE-interest initially to drain the pipes we just
-                            // wrote the acknowledgment messages to
-                            poll.register(&mut connection, token, Ready::readable()|Ready::writable(),PollOpt::level())?;
-                            poll.register(&mut peer.stream, peer_token, Ready::readable()|Ready::writable(),PollOpt::level())?;
-
-                            // create this endpoint
-                            let endpoint = Endpoint {
-                                id: id.to_string(),
-                                dir: req.get_direction(),
-                                stream: connection,
-                                peer_reader: old_reader,
-                                peer_writer: Some(writer2), //None,
-                                peer_token: Some(peer_token),
-                                time_added: SystemTime::now(),
-                            };
-
-                            log!("Added Receiver {:?}", endpoint);
-
-                            ref_endpoints.entry(token).or_insert(endpoint);
-
                         }
-                        portal::Direction::Sender => {
-
-                            /*
-                             * Check that ID is unique
-                             */
-                            let id = req.get_id();
-                            let ref_endpoints = endpoints.borrow();
-                            let search = ref_endpoints.iter()
-                            .find_map(|(key, val)| if *val.id == *id { Some(key) } else { None });
-
-                            // Kill the connection if this ID is being used by another sender
-                            match search {
-                                Some(_) => {continue;}
-                                None => {}
-                            };
-
-                            drop(ref_endpoints);
-
-                            let token = next(&mut unique_token);
-
-                            let (reader, mut writer) = pipe().unwrap();
-
-                            let resp = req.serialize()?;
-                            writer.write_all(&resp)?;
-
-                            let endpoint = Endpoint {
-                                id: req.get_id().to_string(),
-                                dir: req.get_direction(),
-                                stream: connection,
-                                peer_writer: Some(writer),
-                                peer_reader: Some(reader),
-                                peer_token: None,
-                                time_added: SystemTime::now(),
-                            };
-
-                            log!("Added Sender: {:?}", endpoint);
-                            
-                            endpoints.borrow_mut().entry(token).or_insert(endpoint);
-
-                        }
-
-                    }
-                    
+                    });
                 }
                 token => {
 
-                    let mut ref_endpoints = endpoints.borrow_mut();
+                    let mut ref_endpoints = ENDPOINTS.lock().unwrap(); //endpoints.borrow_mut();
 
                     // get the client that will be performing the read/write
                     let client = match ref_endpoints.get_mut(&token) {
@@ -285,13 +155,11 @@ fn main() -> Result<(), Box<dyn Error>> {
 
                     log!("handler finished {:?}", done); 
 
-                    drop(ref_endpoints);
-
                     // If this connection is finished, or our peer has disconnected
                     // shutdown the connection
-                    if done || (trx <= 0 && !endpoints.borrow().contains_key(&peer_token)) {
+                    if done || (trx <= 0 && !ref_endpoints.contains_key(&peer_token)) {
                         log!("Removing endpoint for {:?}", token);
-                        if let Some(mut client) = endpoints.borrow_mut().remove(&token) {
+                        if let Some(mut client) = ref_endpoints.remove(&token) {
                             poll.deregister(&mut client.stream)?;
                             match client.stream.shutdown(std::net::Shutdown::Both) {
                                 Ok(_) => {},

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -178,13 +178,12 @@ fn main() -> Result<(), Box<dyn Error>> {
                     pair.sender_token = next(&mut unique_token);
                     pair.receiver_token =  next(&mut unique_token);
 
-                    poll.register(&pair.sender.stream, pair.sender_token, Ready::readable()|Ready::writable(),PollOpt::edge())?;
-                    poll.register(&pair.receiver.stream, pair.receiver_token, Ready::readable(),PollOpt::level())?;
+                    poll.register(&pair.sender.stream, pair.sender_token, Ready::readable()| Ready::writable(), PollOpt::edge())?;
+                    poll.register(&pair.receiver.stream, pair.receiver_token, Ready::readable(), PollOpt::level())?;
 
                     id_lookup.borrow_mut().entry(pair.sender_token).or_insert_with(|| pair.sender.id.clone());
                     id_lookup.borrow_mut().entry(pair.receiver_token).or_insert_with(|| pair.sender.id.clone());
                     endpoints.borrow_mut().entry(pair.sender.id.clone()).or_insert_with(|| pair);
-
                 }
                 /*
                  * Any other events indicate there is data we need to channel between two TCP connections

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -99,7 +99,13 @@ fn main() -> Result<(), Box<dyn Error>> {
 
                 SERVER => loop {
 
-                   
+                    // Clear old entries before accepting, will keep
+                    // connections < 15 min old
+                    endpoints.borrow_mut().retain(|_, v| 
+                        !v.peer_token.is_none() || (
+                        v.time_added.elapsed().unwrap().as_secs() < 
+                        std::time::Duration::from_secs(60*15).as_secs())); 
+
                     // If this is an event for the server, it means a connection
                     // is ready to be accepted.
                     let (mut connection, _addr) = match server.accept() {

--- a/relay/src/protocol.rs
+++ b/relay/src/protocol.rs
@@ -19,7 +19,7 @@ const PLACEHOLDER: usize = 0;
 pub fn register(mut connection: TcpStream, tx: mio_extras::channel::Sender<EndpointPair>)  -> Result<(), Box<dyn Error>>  {
 
     let mut received_data = Vec::with_capacity(1024);
-    while received_data.len() == 0 {
+    while received_data.is_empty() {
         match networking::recv_generic(&mut connection,&mut received_data) {
             Ok(v) if v < 0 => {break;}, // done recieving
             Ok(_) => {},
@@ -116,10 +116,10 @@ pub fn register(mut connection: TcpStream, tx: mio_extras::channel::Sender<Endpo
             // Kill the connection if this ID is being used by another pending sender
             let search = ref_endpoints.iter()
             .find_map(|(key, val)| if *val.id == *id  { Some(key) } else { None });
-            match search {
-                Some(_) => {return Ok(());}
-                None => {}
-            };
+
+            if search.is_some() {
+                return Ok(());
+            }
 
             // This pipe will be used to send data from Sender->Receiver
             let (reader, mut writer) = pipe().unwrap();

--- a/relay/src/protocol.rs
+++ b/relay/src/protocol.rs
@@ -1,0 +1,160 @@
+use mio::net::TcpStream;
+use portal_lib::Portal;
+use std::error::Error;
+use std::io::Write;
+
+use std::time::SystemTime;
+use os_pipe::{pipe,PipeReader,PipeWriter};
+use mio::{Events, Ready, Poll, Token, PollOpt}; 
+
+
+use crate::{ENDPOINTS,UNIQUE_TOKEN,Endpoint};
+use crate::{networking,logging};
+
+// increment the polling token by one
+// for each new client connection
+fn next(current: &mut Token) -> Token {
+    let next = current.0;
+    current.0 += 1;
+    Token(next)
+}
+
+/**
+ * Attempt to parse a Portal request from the client and match it 
+ * with a peer. If matched, the pair will be added to an event loop 
+ */
+pub fn register(mut connection: TcpStream)  -> Result<(), Box<dyn Error>>  {
+
+    let mut received_data = Vec::with_capacity(1024);
+    while received_data.len() == 0 {
+        match networking::recv_generic(&mut connection,&mut received_data) {
+            Ok(v) if v < 0 => {break;}, // done recieving
+            Ok(_) => {},
+            Err(_) => {
+                break;
+            }
+        }
+    }
+
+    log!("{:?}", received_data.len());
+
+    // attempt to recieve a portal request
+    let req: Portal = match Portal::parse(&received_data) {
+            Ok(r) => r,
+            Err(e) => {
+                log!("{:?}", e);
+                return Err(e.into());
+            },
+    };
+
+    log!("req: {:?}", req);
+
+    // Clear old entries before accepting, will keep
+    // connections < 15 min old
+    let mut ref_endpoints = ENDPOINTS.lock().unwrap();
+    ref_endpoints.retain(|_, v| 
+        !v.peer_token.is_none() || (
+        v.time_added.elapsed().unwrap().as_secs() < 
+        std::time::Duration::from_secs(60*15).as_secs())); 
+
+    // Lookup existing endpoint with this ID
+    let id = req.get_id();
+    let search = ref_endpoints.iter()
+            .find_map(|(key, val)| if *val.id == *id  { Some(key) } else { None });
+
+    match req.get_direction() {
+
+        portal::Direction::Receiver => {
+
+            // Look for peer with identical ID
+            let peer_token  = match search {
+                Some(t) => t.clone(),
+                None => {return Ok(());}
+            };
+            
+
+            //let mut ref_endpoints = endpoints.borrow_mut();
+            let mut peer = match ref_endpoints.get_mut(&peer_token) {
+                Some(p) => p,
+                None => {return Ok(());},
+            };
+
+
+            // if the peer already has a connection, disregard this one
+            if !peer.peer_token.is_none() {
+                let _ = connection.shutdown(std::net::Shutdown::Both);
+                return Ok(());
+            }
+            
+            // assign token since the peer is valid
+            let token = next(&mut UNIQUE_TOKEN.lock().unwrap());
+            
+            // create the pipes for this transfer
+            let (reader2, mut writer2) = pipe().unwrap();
+            
+            // write the acknowledgement response to both pipe endpoints
+            let resp = req.serialize()?;
+            writer2.write_all(&resp)?;
+
+            log!("Finished writing to pipes");
+
+            // update the peer with the pipe information
+            let old_reader = std::mem::replace(&mut peer.peer_reader, Some(reader2));
+            peer.peer_token = Some(token);
+            
+            // set socket to WRITABLE-interest initially to drain the pipes we just
+            // wrote the acknowledgment messages to
+            //poll.register(&mut connection, token, Ready::readable()|Ready::writable(),PollOpt::level())?;
+            //poll.register(&mut peer.stream, peer_token, Ready::readable()|Ready::writable(),PollOpt::level())?;
+
+            // create this endpoint
+            let endpoint = Endpoint {
+                id: id.to_string(),
+                dir: req.get_direction(),
+                stream: connection,
+                peer_reader: old_reader,
+                peer_writer: Some(writer2), //None,
+                peer_token: Some(peer_token),
+                time_added: SystemTime::now(),
+            };
+
+            log!("Added Receiver {:?}", endpoint);
+
+            ref_endpoints.entry(token).or_insert(endpoint);
+
+        }
+        portal::Direction::Sender => {
+
+            // Kill the connection if this ID is being used by another sender
+            match search {
+                Some(_) => {return Ok(());}
+                None => {}
+            };
+
+            let token = next(&mut UNIQUE_TOKEN.lock().unwrap());
+
+            let (reader, mut writer) = pipe().unwrap();
+
+            let resp = req.serialize()?;
+            writer.write_all(&resp)?;
+
+            let endpoint = Endpoint {
+                id: req.get_id().to_string(),
+                dir: req.get_direction(),
+                stream: connection,
+                peer_writer: Some(writer),
+                peer_reader: Some(reader),
+                peer_token: None,
+                time_added: SystemTime::now(),
+            };
+
+            log!("Added Sender: {:?}", endpoint);
+            
+            ref_endpoints.entry(token).or_insert(endpoint);
+
+        }
+
+    }
+    Ok(())
+                    
+}

--- a/relay/src/protocol.rs
+++ b/relay/src/protocol.rs
@@ -4,12 +4,11 @@ use std::error::Error;
 use std::io::Write;
 
 use std::time::SystemTime;
-use os_pipe::{pipe,PipeReader,PipeWriter};
-use mio::{Events, Ready, Poll, Token, PollOpt}; 
+use os_pipe::pipe;
 
 
 use crate::{PENDING_ENDPOINTS,Endpoint,EndpointPair};
-use crate::{networking,logging};
+use crate::networking;
 
 
 /**
@@ -58,13 +57,6 @@ pub fn register(mut connection: TcpStream, tx: mio_extras::channel::Sender<Endpo
     match req.get_direction() {
 
         portal::Direction::Receiver => {
-
-            // Look for peer with identical ID
-            let token  = match search {
-                Some(t) => t.clone(),
-                None => {return Ok(());}
-            };
-            
 
             //let mut ref_endpoints = endpoints.borrow_mut();
             let mut peer = match ref_endpoints.remove(&id.to_string()) {


### PR DESCRIPTION
### Adding:

- Key confirmation round using HKDF 
- Relay efficiency improvements, polling only for read events bidirectionally until the intermediary pipe needs to be drained (i.e request exchange or the end of the transfer).

### Changed
- The main Portal struct's direction field is now a `Direction` instead of an `Option<Direction>`, this is a breaking change since 0.1.0 clients won't be able to communicate with a 0.2.0 relay

### Fixed
- Library Documentation